### PR TITLE
Overide config values from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ utron support yaml, json and toml configurations files. In our todo app, we put 
 
 `utron` searches for a file named `app.json`, or `app.yml` or `app.toml` in the config directory. The first to be found is the one to be used.
 
+You can overide the values from the config file by setting environment variables, thame of the environment variables are shown below( with their details)
+
 This is the content of `config/app.json` file
 
 ```json
@@ -90,16 +92,19 @@ This is the content of `config/app.json` file
 	"database_conn": "postgres://postgres:postgres@localhost/todo"
 }
 ```
-setting      |details
--------------|---------
-app_name     | application name
-base_url     | the base url to use in your views
-port         | port number where the server will be listening to
-verbose      | true value will make every state information logged to stdout
-static_dir   | directory to serve static files e.g images, js or css
-view_dir     | directory to look for views
-database     | the name of the database you use, e.g postgres, mysql, foundation
-database_conn| connection string to your database
+
+You can overide the values from the config file by setting environment variables, name of the environment variables are shown below( with their details)
+
+setting      | environment name|details
+-------------|-----------------|----------------
+app_name     | APP_NAME        |application name
+base_url     | BASE_URL        |the base url to use in your views
+port         | PORT            |port number where the server will be listening to
+verbose      | VERBOSE         |true value will make every state information logged to stdout
+static_dir   | STATIC_DIR      |directory to serve static files e.g images, js or css
+view_dir     | VIEWS_DIR       |directory to look for views
+database     | DATABASE        |the name of the database you use, e.g postgres, mysql, foundation
+database_conn| DATABASE_CONN   |connection string to your database
 
 If you haven't specified explicitly the location of the configuration directory, then it defaults to the directory named `config` in the current working directory.
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,9 @@
 package utron
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 func TestConfig(t *testing.T) {
 	cfgFiles := []string{
@@ -32,4 +35,44 @@ func TestConfig(t *testing.T) {
 		}
 	}
 
+}
+
+func TestConfigEnv(t *testing.T) {
+	fields := []struct {
+		name, env, value string
+	}{
+		{"AppName", "APP_NAME", "utron"},
+		{"BaseURL", "BASE_URL", "http://localhost:8090"},
+		{"Port", "PORT", "8091"},
+		{"ViewsDir", "VIEWS_DIR", "viewTest"},
+		{"StaticDir", "STATIC_DIR", "statics"},
+		{"Database", "DATABASE", "utro_db"},
+		{"DatabaseConn", "DATABASE_CONN", "mydb_conn"},
+	}
+	for _, f := range fields {
+
+		// check out env name maker
+		cm := getEnvName(f.name)
+		if cm != f.env {
+			t.Errorf("expected %s gott %s", f.env, cm)
+		}
+	}
+
+	// set environment values
+	for _, f := range fields {
+		os.Setenv(f.env, f.value)
+	}
+
+	cfg := DefaultConfig()
+	if err := cfg.SyncEnv(); err != nil {
+		t.Errorf("syncing env %v", err)
+	}
+
+	if cfg.Port != 8091 {
+		t.Errorf("expected 8091 got %d instead", cfg.Port)
+	}
+
+	if cfg.AppName != "utron" {
+		t.Errorf("expected utron got %s", cfg.AppName)
+	}
 }


### PR DESCRIPTION
The `*Config.SyncEnv()` method overides the values of any field  that is set in the
environment. The method will look for names in the environment that
matches an uppercassed, underscore separated string of the corresponding
field name.

Example
  For the field AppName, the method will look for APP_NAME in the
environment.

Only int, string and bool fields are overidden, unsupported fields are
ignored.

Closes #5 