### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ step 5 run the app
 
 If you see something like this
 
-	$ 2015/09/15 18:27:24 >>INFO>> staring server at http://localhost:8090
+	$ 2015/09/15 18:27:24 >>INFO>> starting server at http://localhost:8090
 
 Then everything is okay, open `http://localhost:8090` in your browser to start writing your todos.
 If you experience anything different, redo the steps and make sure you did them in order and with no errors. If so, and it still doesn't work, better open an [issue](https://github.com/gernest/utron/issues).

--- a/utron.go
+++ b/utron.go
@@ -239,6 +239,6 @@ func Run() {
 	}
 	Migrate()
 	port := baseApp.cfg.Port
-	logThis.Info("staring server at ", baseApp.cfg.BaseURL)
+	logThis.Info("starting server at ", baseApp.cfg.BaseURL)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), baseApp))
 }


### PR DESCRIPTION
Small typo in the console logs when starting the utron server.