### PR TITLE
Embedded config structs are now scanned from envvars

### DIFF
--- a/config.go
+++ b/config.go
@@ -111,38 +111,61 @@ func (c *Config) saveToFile(path string) error {
 
 // SyncEnv overrides c field's values that are set in the environment.
 //
-// The environment variable names are derived from config fields by underscoring, and uppercasing 
+// The environment variable names are derived from config fields by underscoring, and uppercasing
 // the name. E.g. AppName will have a corresponding environment variable APP_NAME
 //
 // NOTE only int, string and bool fields are supported and the corresponding values are set.
 // when the field value is not supported it is ignored.
 func (c *Config) SyncEnv() error {
 	cfg := reflect.ValueOf(c).Elem()
+	return syncEnv(cfg, "")
+}
+
+func syncEnv(cfg reflect.Value, prefix string) error {
 	cTyp := cfg.Type()
 
-	for k := range make([]struct{}, cTyp.NumField()) {
-		field := cTyp.Field(k)
+	for i := 0; i < cTyp.NumField(); i++ {
+		field := cTyp.Field(i)
 
-		cm := getEnvName(field.Name)
-		env := os.Getenv(cm)
-		if env == "" {
+		ename := strings.ToUpper(getEnvName(field.Name))
+		if prefix != "" {
+			ename = strings.ToUpper(prefix) + "_" + ename
+		}
+
+		env := os.Getenv(ename)
+
+		if env == "" && field.Type.Kind() != reflect.Struct {
 			continue
 		}
+
 		switch field.Type.Kind() {
 		case reflect.String:
 			cfg.FieldByName(field.Name).SetString(env)
 		case reflect.Int:
 			v, err := strconv.Atoi(env)
 			if err != nil {
-				return fmt.Errorf("utron: loading config field %s %v", field.Name, err)
+				return fmt.Errorf("utron: loading config field %s %v", ename, err)
 			}
 			cfg.FieldByName(field.Name).Set(reflect.ValueOf(v))
 		case reflect.Bool:
 			b, err := strconv.ParseBool(env)
 			if err != nil {
-				return fmt.Errorf("utron: loading config field %s %v", field.Name, err)
+				return fmt.Errorf("utron: loading config field %s %v", ename, err)
 			}
 			cfg.FieldByName(field.Name).SetBool(b)
+		case reflect.Uint:
+			v, err := strconv.ParseUint(env, 10, 0)
+			if err != nil {
+				return fmt.Errorf("utron: loading config field %s %v", ename, err)
+			}
+			cfg.FieldByName(field.Name).Set(reflect.ValueOf(v))
+		case reflect.Struct:
+			err := syncEnv(cfg.FieldByName(field.Name), ename)
+			if err != nil {
+				return err
+			}
+		default:
+			return errors.New(fmt.Sprintf("utron: unknown config type for field %v (%v)", ename, field.Type.Kind().String()))
 		}
 
 	}


### PR DESCRIPTION
This commit adds recursive scanning of Config struct fields from
environment variables. Embedded fields are separated by underscore.
Example:

```
type Config struct {
  Database struct {
    Kind string
    URI string
  }
}
```

now reads `DATABASE_KIND` and `DATABASE_URI` environment variables.