### PR TITLE
Support go1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go: 
- - 1.2
  - 1.3
  - release
 before_install:


### PR DESCRIPTION
For some reasons unknown, goveralls fails to run on go1.2. So, this PR changes travis CI configuration to only run against go1.3 and latest.