### PR TITLE
Make app config more verbose, and enable full addr on ListenAndServe

### DIFF
--- a/utron.go
+++ b/utron.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 )
 
 var baseApp *App
@@ -240,7 +241,20 @@ func Run() {
 	if baseApp.cfg.Automigrate {
 		Migrate()
 	}
-	port := baseApp.cfg.Port
+
 	logThis.Info("starting server at ", baseApp.cfg.BaseURL)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), baseApp))
+
+	scheme := baseApp.cfg.Scheme
+	host := baseApp.cfg.Host
+	port := baseApp.cfg.Port
+	addr := fmt.Sprintf("%s:%s", host, strconv.Itoa(port))
+
+	switch scheme {
+	case "http":
+		log.Fatal(http.ListenAndServe(addr, baseApp))
+	case "https":
+		log.Fatal("https not yet implemented") // TODO - implement ListenAndServeTLS
+	default:
+		log.Fatalf("%s is not a valid scheme", scheme)
+	}
 }


### PR DESCRIPTION
This enables the ability to be more flexible with app configuration. You can now configure scheme and host in addition to port.

I noticed currently the server will let you configure your port in the base_url and the port in the config differently, and will tell you the base_url port is being used when it is not. This change looks for mismatches and fails instead of telling you something that isn't the case or assuming you want one over the other.

Currently you can say "localhost" but you'll actually bind to public addresses. This change in conjunction with the configuration changes will allow you to actually bind to the address you intend to via http.ListenAndServe().

I left a TODO in here to enable TLS listen, but I didn't want to implement that before checking on the rest first. If this merges I would be happy to implement the TLS listen configuration after talking through what is wanted there on gitter or issues.
