### PR TITLE
Add Log field to Context

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -73,6 +73,7 @@ func (a *App) options() *router.Options {
 		Model:  a.Model,
 		View:   a.View,
 		Config: a.Config,
+		Log:    a.Log,
 	}
 }
 

--- a/base/context.go
+++ b/base/context.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/gernest/utron/config"
+	"github.com/gernest/utron/logger"
 	"github.com/gernest/utron/models"
 	"github.com/gernest/utron/view"
 	"github.com/gorilla/context"
@@ -55,6 +56,8 @@ type Context struct {
 
 	//DB is the database stuff, with all models registered
 	DB *models.Model
+
+	Log logger.Logger
 
 	request    *http.Request
 	response   http.ResponseWriter

--- a/base/context.go
+++ b/base/context.go
@@ -60,7 +60,7 @@ type Context struct {
 	response   http.ResponseWriter
 	out        io.ReadWriter
 	isCommited bool
-	View       view.View
+	view       view.View
 }
 
 // NewContext creates new context for the given w and r
@@ -136,7 +136,7 @@ func (c *Context) SetData(key, value interface{}) {
 func (c *Context) Set(value interface{}) {
 	switch value.(type) {
 	case view.View:
-		c.View = value.(view.View)
+		c.view = value.(view.View)
 	case *http.Request:
 		c.request = value.(*http.Request)
 	case http.ResponseWriter:
@@ -161,13 +161,13 @@ func (c *Context) Commit() error {
 	if c.isCommited {
 		return errors.New("already committed")
 	}
-	if c.Template != "" && c.View != nil {
+	if c.Template != "" && c.view != nil {
 		out := &bytes.Buffer{}
 
 		if c.Cfg != nil {
 			c.Data["Config"] = c.Cfg // add configuration to the view data context
 		}
-		err := c.View.Render(out, c.Template, c.Data)
+		err := c.view.Render(out, c.Template, c.Data)
 		if err != nil {
 			return err
 		}

--- a/router/routes.go
+++ b/router/routes.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gernest/utron/base"
 	"github.com/gernest/utron/config"
 	"github.com/gernest/utron/controller"
+	"github.com/gernest/utron/logger"
 	"github.com/gernest/utron/models"
 	"github.com/gernest/utron/view"
 	"github.com/gorilla/mux"
@@ -28,6 +29,8 @@ var (
 
 	// ErrRouteStringFormat is returned when the route string is of the wrong format
 	ErrRouteStringFormat = errors.New("wrong route string, example is\" get,post;/hello/world;Hello\"")
+
+	defaultLogger = logger.NewDefaultLogger(os.Stdout)
 )
 
 // Router registers routes and handlers. It embeds gorilla mux Router
@@ -43,6 +46,7 @@ type Options struct {
 	Model  *models.Model
 	View   view.View
 	Config *config.Config
+	Log    logger.Logger
 }
 
 // NewRouter returns a new Router, if app is passed then it is used
@@ -358,8 +362,16 @@ func (r *Router) prepareContext(ctx *base.Context) {
 		if r.Options.Model != nil {
 			ctx.DB = r.Options.Model
 		}
+		if r.Options.Log != nil {
+			ctx.Log = r.Options.Log
+		}
 	}
 
+	// It is a good idea to ensure that a well prepared context always has the
+	// Log field set.
+	if ctx.Log == nil {
+		ctx.Log = defaultLogger
+	}
 }
 
 // executes the method fn on Controller ctrl, it sets context.


### PR DESCRIPTION
This is adds Log field to Context, allowing the Controller to log messages using the application logger.

This field is ensured to never be nil. If there is no any application logger set then the default logger which writes to stdout is used.