### PR TITLE
Fix misspell

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -24,7 +24,7 @@
 //
 // There are many frameworks out there, you might be wondering why do we need
 // yet another framework?. We probably don't.. Utron is just a summary of the
-// tools, and techinques I use to develop web  applications in Go.
+// tools, and techniques I use to develop web  applications in Go.
 //
 // This includes the best libraries, and the best organization of the code base.
 // Utron has one of the very handy Controller( you will see more details in the

--- a/flash/flash.go
+++ b/flash/flash.go
@@ -57,7 +57,7 @@ func GetFlashes(ctx *base.Context, name, key string) (Flashes, error) {
 
 // AddFlashToCtx takes flash messages stored in a cookie which is associated with the
 // request found in ctx, and puts them inside the ctx object. The flash messages can then
-// be retrived by calling ctx.Get( FlashKey).
+// be retrieved by calling ctx.Get( FlashKey).
 //
 // NOTE When there are no flash messages then nothing is set.
 func AddFlashToCtx(ctx *base.Context, name, key string) error {


### PR DESCRIPTION
After seeing the Go Report Card I saw there were a couple of misspelled words:

utron/flash/flash.go
Line 60: warning: "retrived" is a misspelling of "retrieved" (misspell)
utron/doc.go
Line 27: warning: "techinques" is a misspelling of "techniques" (misspell)